### PR TITLE
Refactor api to follow RESTful conventions and update validation

### DIFF
--- a/src/controllers/artist.ts
+++ b/src/controllers/artist.ts
@@ -5,7 +5,7 @@ import logger from '@/config/logger'
 import { ArtistService } from '@/services/artist'
 import { validateRequest } from '@/middlewares/validate-request'
 import { getValidated } from '@/utils/validation'
-import { TGetBookingData, TGetBookingsData } from '@/types/artist'
+import { TGetBookingData, TGetBookingsData, TUpdateBookingStatus } from '@/types/artist'
 
 const router: Router = Router()
 
@@ -70,6 +70,31 @@ router.get(
             const data = await service.getBookingById(userId, +bookingId)
 
             res.json({
+                data: data,
+            })
+        } catch (err) {
+            next(err)
+        }
+    }
+)
+
+router.patch(
+    '/:userId/bookings/:bookingId',
+    validateRequest({
+        params: z.object({ userId: z.string(), bookingId: z.string() }),
+        body: z.object({
+            status: z.enum(BookingStatus),
+        }),
+    }),
+    async (req, res, next) => {
+        const service = new ArtistService({ prisma, logger })
+
+        try {
+            const getReq = getValidated<TUpdateBookingStatus>(req)
+            const { params, body } = getReq
+            const data = await service.updateBookingStatus(+params.bookingId, body.status)
+
+            res.status(201).json({
                 data: data,
             })
         } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import cors from 'cors'
 import compression from 'compression'
 import env from '@/config/env'
 import logger from '@/config/logger'
-import artists from '@/controllers/artist'
+import bookingRouter from '@/controllers/booking'
 import apiError from '@/middlewares/api-error'
 
 const app: Express = express()
@@ -32,7 +32,7 @@ app.use(
     })
 )
 
-app.use('/v1/artists', artists)
+app.use('/v1/bookings', bookingRouter)
 
 app.use('/ping', (req, res) => {
     res.json({ message: 'ping' })

--- a/src/services/booking.ts
+++ b/src/services/booking.ts
@@ -2,7 +2,7 @@ import { PrismaClient, User, Booking, BookingStatus } from '@/prisma/index'
 import { Logger } from 'winston'
 import { TBookingQuery } from '@/types/artist'
 
-interface IArtistService {
+interface IBookingService {
     getBooking(userId: User['id'], queries: TBookingQuery): Promise<Booking[]>
     // getBookingById(userId: User['id'], bookingId: Booking['id']): Promise<Booking>
 }
@@ -12,7 +12,7 @@ interface Context {
     logger: Logger
 }
 
-export class ArtistService implements IArtistService {
+export class BookingService implements IBookingService {
     constructor(private ctx: Context) {}
 
     public async getBooking(userId: User['id'], queries: TBookingQuery) {
@@ -42,24 +42,10 @@ export class ArtistService implements IArtistService {
         })
     }
 
-    public async getBookingById(userId: User['id'], bookingId: Booking['id']) {
+    public async getBookingById(id: Booking['id']) {
         return await this.ctx.prisma.booking.findUnique({
             where: {
-                id: bookingId,
-                AND: {
-                    artistId: userId,
-                },
-            },
-        })
-    }
-
-    public async getBookingByStatus(userId: User['id'], status: BookingStatus) {
-        return await this.ctx.prisma.booking.findMany({
-            where: {
-                artistId: userId,
-                AND: {
-                    status: status,
-                },
+                id: id,
             },
         })
     }

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -1,20 +1,20 @@
 import { BookingStatus, Booking } from '@/prisma/index'
 
 export type TGetBookingsData = {
-    params: { userId: string }
     query: TBookingQuery
 }
 
 export type TGetBookingData = {
-    params: { userId: string; bookingId: string }
+    params: { id: string }
 }
 
 export type TUpdateBookingStatus = {
-    params: { userId: string; bookingId: string }
+    query: { id: string }
     body: { status: BookingStatus }
 }
 
 export type TBookingQuery = {
+    id: string
     status?: BookingStatus | undefined
     startTimeFrom?: Booking['startTime'] | undefined
     endTimeTo?: Booking['endTime'] | undefined

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -9,6 +9,11 @@ export type TGetBookingData = {
     params: { userId: string; bookingId: string }
 }
 
+export type TUpdateBookingStatus = {
+    params: { userId: string; bookingId: string }
+    body: { status: BookingStatus }
+}
+
 export type TBookingQuery = {
     status?: BookingStatus | undefined
     startTimeFrom?: Booking['startTime'] | undefined

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -1,15 +1,15 @@
 import { BookingStatus, Booking } from '@/prisma/index'
 
-export type TGetBookingsData = {
+export type TGetBookings = {
     query: TBookingQuery
 }
 
-export type TGetBookingData = {
+export type TGetBooking = {
     params: { id: string }
 }
 
-export type TUpdateBookingStatus = {
-    query: { id: string }
+export type TUpdateBooking = {
+    params: { id: string }
     body: { status: BookingStatus }
 }
 
@@ -18,5 +18,5 @@ export type TBookingQuery = {
     status?: BookingStatus | undefined
     startTimeFrom?: Booking['startTime'] | undefined
     endTimeTo?: Booking['endTime'] | undefined
-    bookingDate?: Booking['bookingDate'] | undefined
+    date?: Booking['bookingDate'] | undefined
 }


### PR DESCRIPTION
This PR includes the following fixes:

- The API should follow RESTful design principles. Since the API provides specific services and supports two types of users (client and artist), it's a good idea to adopt RESTful patterns.
(Note: Both patterns follow RESTful conventions and work as expected.)
Instead of:
`GET /v1/users/collection`
We can use:
`GET /v1/collection`
- Updated validation logic. Previously, some routes used the `string` type when validating query parameters from the request. I later discovered that [Zod](https://zod.dev/) supports the `cuid` type, which properly validates CUIDs in incoming requests.

